### PR TITLE
Fix issues with test data loading and reset

### DIFF
--- a/election-api-javascript/src/resultsController.js
+++ b/election-api-javascript/src/resultsController.js
@@ -19,5 +19,4 @@ function scoreboard() {
     //  Left blank for you to fill in
 }
 
-
 module.exports = { getResult, newResult, reset, scoreboard };

--- a/election-api-javascript/src/resultsController.js
+++ b/election-api-javascript/src/resultsController.js
@@ -11,8 +11,13 @@ function newResult(result) {
     return {};
 }
 
+function reset() {
+    store.reset();
+}
+
 function scoreboard() {
     //  Left blank for you to fill in
 }
 
-module.exports = { getResult, newResult, scoreboard };
+
+module.exports = { getResult, newResult, reset, scoreboard };

--- a/election-api-javascript/src/resultsService.js
+++ b/election-api-javascript/src/resultsService.js
@@ -16,7 +16,7 @@ function resultStore() {
     }
 
     function reset() {
-        store = [];
+        store.splice(0);
     }
 
     return {

--- a/election-api-javascript/src/server.js
+++ b/election-api-javascript/src/server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getResult, newResult, scoreboard } = require('./resultsController');
+const { getResult, newResult, reset, scoreboard } = require('./resultsController');
 
 const server = express();
 server.use(express.json());
@@ -16,4 +16,8 @@ server.get('/scoreboard', (req, res) => {
     res.send(scoreboard());
 });
 
-module.exports.default = server;
+function resetScores() {
+  reset();
+}
+
+module.exports = { default: server, resetScores };

--- a/election-api-javascript/src/server.js
+++ b/election-api-javascript/src/server.js
@@ -16,8 +16,4 @@ server.get('/scoreboard', (req, res) => {
     res.send(scoreboard());
 });
 
-function resetScores() {
-  reset();
-}
-
-module.exports = { default: server, resetScores };
+module.exports = { default: server, resetScores: reset };

--- a/election-api-javascript/tasks.md
+++ b/election-api-javascript/tasks.md
@@ -11,7 +11,7 @@ For each constituency a winner can be declared:
 Someone wins in the UK if they receive half of the constituency seats in Parliament (325).
 So if a party has received 325 or more seats it can be declared the winner overall.
 
-Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 349.
+Note: 325 isn't a proper majority of 650 but the speaker of the house makes the effective number of voting MPs 649.
 
 The scoreboard should show:
 - The seats for each party

--- a/election-api-javascript/test/scoreboard.spec.js
+++ b/election-api-javascript/test/scoreboard.spec.js
@@ -23,11 +23,10 @@ function fetchScoreboard(server) {
 }
 
 describe('Scoreboard Tests', () => {
-    let server;
+    const server = request(expressServer);
 
     beforeEach(() => {
         resetScores();
-        server = request(expressServer);
     });
 
     test('first 5', async () => {

--- a/election-api-javascript/test/scoreboard.spec.js
+++ b/election-api-javascript/test/scoreboard.spec.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
 const request = require('supertest');
-const { default: expressServer } = require('../src/server');
+const { default: expressServer, resetScores } = require('../src/server');
 
 const resultsSamplesPath = './test/resources/sample-election-results';
 
 function loadAndPostResultFile(server, num) {
     const fileNumber = new String(parseInt(num, 10)).padStart(3, '0');
     const result = fs.readFileSync(`${resultsSamplesPath}/result${fileNumber}.json`);
-    return server.post('/result', result);
+    return server.post('/result').send(JSON.parse(result));
 }
 
 async function loadResults(server, quantity) {
@@ -26,10 +26,8 @@ describe('Scoreboard Tests', () => {
     let server;
 
     beforeEach(() => {
+        resetScores();
         server = request(expressServer);
-    });
-
-    afterEach(() => {
     });
 
     test('first 5', async () => {


### PR DESCRIPTION
This is to fix two issues with testing:
- Results data was empty when loading due to a mistake in how to give a POST body to supertest
- Results data was not resetting between tests because supertest starts the server listening, but you do not have the ability to stop it because it manages the server socket

The 2nd issue was resolved with a method provided alongside the server instance that has direct access to the data, but would not normally be externally available. It also required changing the reset itself because it was erroring trying to change the value of a const.