### PR TITLE
JS UI: Make test data match implementation

### DIFF
--- a/election-ui-javascript/src/components/Scoreboard.test.js
+++ b/election-ui-javascript/src/components/Scoreboard.test.js
@@ -11,7 +11,7 @@ const mockDataFetcher = () => {
       results: [
         {
           'party': 'Independent',
-          'candidate': 'Lord Buckethead',
+          'candidateId': 2,
           'votes': '9900'
         }
       ]

--- a/election-ui-javascript/src/components/Scorecard/Scorecard.test.js
+++ b/election-ui-javascript/src/components/Scorecard/Scorecard.test.js
@@ -4,7 +4,7 @@ import Scorecard from '.';
 const results = [
   {
     'party': 'Green',
-    'candidate': '',
+    'candidateId': 2,
     'votes': '1056'
   }
 ];

--- a/election-ui-javascript/src/dataFetcher/index.test.js
+++ b/election-ui-javascript/src/dataFetcher/index.test.js
@@ -10,7 +10,7 @@ const mockFakeApi = () => {
       results: [
         {
           'party': 'Independent',
-          'candidate': 'Lord Buckethead',
+          'candidateId': 2,
           'votes': '9900'
         }
       ]


### PR DESCRIPTION
The test data doesn't match the implementation. The fake API returns `result` objects with a `candidateId` not a `candidate`.