### PR TITLE
Adds Lombok to the Java API REAMDE

### DIFF
--- a/election-api-java/README.md
+++ b/election-api-java/README.md
@@ -23,7 +23,9 @@ During your assessment we will ask you to work though the task in `tasks.md` wit
 
 ## Prerequisites
 - Java 11
+- [Lombok](https://projectlombok.org/)
 
+### Please ensure that the project builds without error within your choice of IDE. This should require no changes to the files in this repository.
 ### To Build
 macOS / 'nix
 


### PR DESCRIPTION
Lombok is unusual as a library as it manipulates the AST at compile
time to magically generate "boilerplate code". This means that IDE's
need to be configured to understand this otherwise they'll flag up
compiler errors for the missing code that Lombok will generate.
Setting up an IDE for Lombok can take some time, sometimes requiring
a combination of plugins and project settings, and as such, steps should
be taken to avoid having to do this work during a candidates assessment.

I've also taken the opportunity to reiterate that the candidate should
ensure that the project builds successfully in their IDE as it is
possible to come away with the idea that the code is broken and the
first task of the assessment would be to fix it.